### PR TITLE
call launch_tor with the tor_binary from config

### DIFF
--- a/ooni/runner.py
+++ b/ooni/runner.py
@@ -516,6 +516,7 @@ def startTor():
     log.debug("Setting SOCKS port as %s" % tor_config.SocksPort)
 
     d = launch_tor(tor_config, reactor,
+            tor_binary=config.advanced.tor_binary,
             progress_updates=updates)
     d.addCallback(setup_complete)
     d.addErrback(setup_failed)


### PR DESCRIPTION
Otherwise, the default is supplied by txtorcon as /usr/sbin/tor
