### PR TITLE
Add default oonib reporter

### DIFF
--- a/collector
+++ b/collector
@@ -1,0 +1,1 @@
+httpo://nkvphnp3p6agi5qq.onion

--- a/ooni/oonicli.py
+++ b/ooni/oonicli.py
@@ -28,7 +28,8 @@ class Options(usage.Options):
                 " files listed on the command line")
 
     optFlags = [["help", "h"],
-                ["resume", "r"]]
+                ["resume", "r"],
+                ["no-default-reporter", "n"]]
 
     optParameters = [["reportfile", "o", None, "report file name"],
                      ["testdeck", "i", None,

--- a/ooni/runner.py
+++ b/ooni/runner.py
@@ -4,6 +4,7 @@ import time
 import inspect
 import traceback
 import itertools
+import random
 
 import yaml
 
@@ -412,6 +413,14 @@ def runTestCases(test_cases, options, cmd_line_options):
     log.debug("cmd_line_options %s" % dict(cmd_line_options))
 
     test_inputs = options['inputs']
+
+    # Set a default reporter
+    if not cmd_line_options['collector'] and not \
+        cmd_line_options['no-default-reporter']:
+        with open('collector') as f:
+            reporter_url = random.choice(f.readlines())
+            reporter_url = reporter_url.split('#')[0].strip()
+            cmd_line_options['collector'] = reporter_url
 
     oonib_reporter = OONIBReporter(cmd_line_options)
     yaml_reporter = YAMLReporter(cmd_line_options)


### PR DESCRIPTION
Adds a list of default oonib collector addresses, and selects one at random for each test. Also adds a command-line flag (-n) to disable this behavior.
