### PR TITLE
Flatten the reporter keys

### DIFF
--- a/ooni/reporter.py
+++ b/ooni/reporter.py
@@ -183,15 +183,12 @@ class OReporter(object):
         else:
             test_input = test.input
 
-        test_started = test._start_time
-        test_runtime = time.time() - test_started
+        test_report['input'] = test_input
+        test_report['test_name'] = test_name
+        test_report['test_started'] = test._start_time
+        test_report['test_runtime'] = time.time() - test._start_time
 
-        report = {'input': test_input,
-                'test_name': test_name,
-                'test_started': test_started,
-                'test_runtime': test_runtime,
-                'report': test_report}
-        return defer.maybeDeferred(self.writeReportEntry, report)
+        return defer.maybeDeferred(self.writeReportEntry, test_report)
 
 class YAMLReporter(OReporter):
     """

--- a/scripts/example_parser.py
+++ b/scripts/example_parser.py
@@ -1,5 +1,6 @@
 # This is an example of how to parse ooniprobe reports
 
+from pprint import pprint
 import yaml
 import sys
 print "Opening %s" % sys.argv[1]
@@ -15,8 +16,6 @@ print "Test name: %s" % report_header['test_name']
 print "Test version: %s" % report_header['test_version']
 
 for report_entry in yamloo:
-    print "Test: %s" % report_entry['test_name']
-    print "Input: %s" % report_entry['input']
-    print "Report: %s" % report_entry['report']
+    pprint(report_entry)
 
 f.close()


### PR DESCRIPTION
This makes it so that reports do not present one level of nesting.
- Update example parser script to reflect changes in report format

These changes are needed for having the data format be with one less layer of nesting.
