### PR TITLE
Add DNS injection test

### DIFF
--- a/nettests/experimental/dns_injection.py
+++ b/nettests/experimental/dns_injection.py
@@ -41,7 +41,7 @@ class DNSInjectionTest(dnst.DNSTest):
             if line.startswith('http://'):
                 yield line.replace('http://', '').replace('/', '').strip()
             else:
-                yield x.strip()
+                yield line.strip()
         fp.close()
 
     def test_injection(self):


### PR DESCRIPTION
This test is able to detect censorship when the answers to UDP based DNS queries are being spoofed.

It works even if you are outside of the country where you wish to perform the measurement, you just need an IP address inside of the country.

Note: this test was suggested by zion on trac here: https://trac.torproject.org/projects/tor/wiki/doc/OONI/Tests/DNSInjection

This will work for example to test which sites are being filtered inside of china:

`./bin/ooniprobe nettests/experimental/dns_injection.py -f inputs/ooni-inputs/processed/alexa-top-1k.txt -r 220.192.0.1`

```
###########################################
# OONI Probe Report for DNS Injection test
# Sat Mar  2 20:28:26 2013
###########################################

---
options:
  collector: httpo://nkvphnp3p6agi5qq.onion
  help: 0
  logfile: null
  no-default-reporter: 0
  parallelism: '10'
  pcapfile: null
  reportfile: null
  resume: 0
  subargs: [-f, inputs/ooni-inputs/processed/alexa-top-1k.txt, -r, 220.192.0.1]
  test: nettests/experimental/dns_injection.py
probe_asn: null
probe_cc: null
probe_ip: null
software_name: ooniprobe
software_version: 0.0.10
start_time: 1362248906.0
test_name: DNS Injection
test_version: '0.1'
...

---
injected: true
input: facebook.com
queries:
- query: '[Query(''facebook.com'', 1, 1)]'
  query_type: A
  resolver: [220.192.0.1, 53]
test_name: test_injection
test_runtime: 0.3477039337158203
test_started: 1362252506.732914
...

---
injected: true
input: youtube.com
queries:
- addrs: [78.16.49.15]
  answers:
  - [<RR name=youtube.com type=A class=IN ttl=31293s auth=True>, <A address=78.16.49.15
      ttl=31293>]
  query: '[Query(''youtube.com'', 1, 1)]'
  query_type: A
  resolver: [220.192.0.1, 53]
test_name: test_injection
test_runtime: 0.3509399890899658
test_started: 1362252506.733631
...

---
injected: true
input: twitter.com
queries:
- addrs: [59.24.3.173]
  answers:
  - [<RR name=twitter.com type=A class=IN ttl=21937s auth=False>, <A address=59.24.3.173
      ttl=21937>]
  query: '[Query(''twitter.com'', 1, 1)]'
  query_type: A
  resolver: [220.192.0.1, 53]
test_name: test_injection
test_runtime: 0.351452112197876
test_started: 1362252506.737242
...

---
injected: false
input: google.com
queries:
- failure: deferred_timeout_error
  query: '[Query(''google.com'', 1, 1)]'
  query_type: A
  resolver: [220.192.0.1, 53]
test_name: test_injection
test_runtime: 3.0029098987579346
test_started: 1362252506.73108
...

---
injected: false
input: yahoo.com
queries:
- failure: deferred_timeout_error
  query: '[Query(''yahoo.com'', 1, 1)]'
  query_type: A
  resolver: [220.192.0.1, 53]
test_name: test_injection
test_runtime: 3.003868818283081
test_started: 1362252506.734332
...
```
