### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Basic system requirements:
 
 On Debian or Ubuntu GNU/Linux based systems these can be installed with:
 
-  sudo apt-get install git-core python python-pip python-dev build-essential tor tor-geoipdb
+  sudo apt-get install git-core python python-pip python-dev build-essential tor tor-geoipdb tcpdump
 
 Other packages that may be of interest:
 


### PR DESCRIPTION
tcpdump seems to be required on a clean debian (6.0.7) install.

(this change may also need making in other places)
