### PR TITLE
Set pcap name for each NetTest, and use consistent timestamps.

### DIFF
--- a/ooni/config.py
+++ b/ooni/config.py
@@ -122,22 +122,7 @@ if not resume_filename:
         with open(resume_filename, 'w+') as f: pass
 
 
-def generatePcapFilename(cmd_line_options=None):
-    if not cmd_line_options:
-        cmd_line_options = {}
-
-    if 'pcapfile' in cmd_line_options:
-        pcap_filename = cmd_line_options['pcapfile']
-    else:
-        if 'test' in cmd_line_options:
-            test_filename = os.path.basename(cmd_line_options['test'])
-        elif 'testdeck' in cmd_line_options:
-            test_filename = os.path.basename(cmd_line_options['testdeck'])
-        else:
-            test_filename = ''
-
-        test_name = '.'.join(test_filename.split(".")[:-1])
-        frm_str = "report_%s_" + otime.timestamp() + ".%s"
-        pcap_filename = frm_str % (test_name, "pcap")
-
-    return pcap_filename
+def generatePcapFilename(testDetails):
+    test_name, start_time = testDetails['test_name'], testDetails['start_time']
+    start_time = otime.epochToTimestamp(start_time)
+    return "report-%s-%s.%s" % (test_name, start_time, "pcap")

--- a/ooni/nettest.py
+++ b/ooni/nettest.py
@@ -9,8 +9,7 @@ from ooni import geoip
 from ooni.tasks import Measurement
 from ooni.utils import log, checkForRoot, geodata
 from ooni import config
-from ooni import otime
-
+import time
 from ooni import errors as e
 
 from inspect import getmembers
@@ -69,7 +68,7 @@ class NetTestLoader(object):
                 or ('countrycode' not in client_geodata):
             client_geodata['countrycode'] = None
 
-        test_details = {'start_time': otime.utcTimeNow(),
+        test_details = {'start_time': time.time(),
             'probe_asn': client_geodata['asn'],
             'probe_cc': client_geodata['countrycode'],
             'probe_ip': client_geodata['ip'],

--- a/ooni/otime.py
+++ b/ooni/otime.py
@@ -87,3 +87,5 @@ def timestamp(t=None):
     ISO8601 = "%Y-%m-%dT%H%M%SZ"
     return t.strftime(ISO8601)
 
+def epochToTimestamp(seconds):
+    return timestamp(datetime.utcfromtimestamp(seconds))


### PR DESCRIPTION
Fixes the pcap filename generation so that each ooni report has an accompanying pcap file with the same filename prefix.

Also makes our use of timestamps consistent, though we may want to switch to using ooni.otime everywhere else instead.
