### PR TITLE
Use generic L3RawSocket rather than OS specific L3PacketSocket

### DIFF
--- a/ooni/utils/txscapy.py
+++ b/ooni/utils/txscapy.py
@@ -10,6 +10,7 @@ from twisted.internet import defer, abstract
 from zope.interface import implements
 
 from scapy.config import conf
+from scapy.supersocket import L3RawSocket
 
 from ooni.utils import log
 from ooni.settings import config
@@ -129,9 +130,7 @@ class ScapyFactory(abstract.FileDescriptor):
         if interface == 'auto':
             interface = getDefaultIface()
         if not super_socket:
-            super_socket = conf.L3socket(iface=interface,
-                    promisc=True, filter='')
-            #super_socket = conf.L2socket(iface=interface)
+            super_socket = L3RawSocket(iface=interface, promisc=True)
 
         self.protocols = []
         fdesc._setCloseOnExec(super_socket.ins.fileno())


### PR DESCRIPTION
Experimental: Seems to work in tests, but has not yet been tested
on any platform other than Linux. Solves the problem reported in
https://github.com/TheTorProject/ooni-probe/issues/214
