### PR TITLE
Do not raise an exception on no input processor.

### DIFF
--- a/ooni/nettest.py
+++ b/ooni/nettest.py
@@ -667,7 +667,7 @@ class NetTestCase(object):
         anything that gets written to the object self.report[] will be added to
         the final test report.
         """
-        raise NoPostProcessor
+        pass
 
     def inputProcessor(self, filename):
         """


### PR DESCRIPTION
Currently when you run a test that does not have a post processor it will raise an exception leading to unittests (amongst other things) to fail. This fixes it.
