### PR TITLE
Properly encode the helper address

### DIFF
--- a/ooni/deck.py
+++ b/ooni/deck.py
@@ -177,7 +177,7 @@ class Deck(InputFile):
                     continue
                 test_helper = response[th['name']]
                 log.msg("Using this helper: %s" % test_helper)
-                th['test_class'].localOptions[th['option']] = test_helper['address']
+                th['test_class'].localOptions[th['option']] = test_helper['address'].encode('utf-8')
                 if net_test_loader in requires_collector:
                     net_test_loader.collector = test_helper['collector'].encode('utf-8')
 


### PR DESCRIPTION
Fixes a bug where the returned address is unicode encoded and twisted web Agent throws an error.
