### PR TITLE
Check to see if a required option is a test helper we can look up

### DIFF
--- a/ooni/deck.py
+++ b/ooni/deck.py
@@ -133,8 +133,8 @@ class Deck(InputFile):
             for rth in net_test_loader.requiredTestHelpers:
                 if option_name.message == rth['option']:
                     break
-            else:
-                raise
+                else:
+                    raise
         self.netTestLoaders.append(net_test_loader)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
If a bouncer exists, we should not require the user to supply an option that is also a required test helper that the bouncer would otherwise supply.
