### PR TITLE
Removed dated reference to subversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,6 @@ up to date.
 The version of pypcap and libdnet ooniprobe is current tested with are
 libdnet-1.12 and pypcap 1.1, any other version should be considered untested.
 
-If you don't already have Subversion installed:
-
-```
-sudo apt-get install subversion
-```
-
 For libdnet:
 
 ```


### PR DESCRIPTION
The subversion requirement was introduced in
ba331316b0cff1d71fb477487da93be0b8494b8d for checking out pypcap.
Commit 1b53eb99e6c384b7f43f45f306e209894c8476bb switch to using a git url.
