### PR TITLE
Add required package libpcap0.8-dev

### DIFF
--- a/setup-dependencies.sh
+++ b/setup-dependencies.sh
@@ -896,7 +896,7 @@ case $DISTRO_VERSION in
   echo "[+] Updating OS package list...";
   sudo sudo apt-get update 2>&1 > /dev/null;
   echo "[+] Installing packages for your system...";
-  DO "sudo apt-get -y install curl git-core python python-dev python-setuptools build-essential libdumbnet1 python-dumbnet python-libpcap python-dnspython tor tor-geoipdb libgeoip-dev" "0"
+  DO "sudo apt-get -y install curl git-core python python-dev python-setuptools build-essential libdumbnet1 python-dumbnet python-libpcap python-dnspython tor tor-geoipdb libgeoip-dev libpcap0.8-dev" "0"
 
   if [ "$PRIV_MODE" -eq "0" ]; then
     echo "[+] Using virtualenvironment..."


### PR DESCRIPTION
While running: setup-dependencies.sh -u

```
Running setup.py (path:/home/user/.virtualenvs/ooniprobe/build/pypcap/setup.py) egg_info for package pypcap
    pcap.h not found
```
