### PR TITLE
Add support for Ubuntu releases in setup script

### DIFF
--- a/setup-dependencies.sh
+++ b/setup-dependencies.sh
@@ -867,7 +867,11 @@ install_virtualenv_securely() {
 }
 
 case $DISTRO_VERSION in
+<<<<<<< Updated upstream
   natty|wheezy|squeeze|precise|n/a)
+=======
+  natty|wheezy|squeeze|precise|n/a|raring|saucy|trusty|utopic)
+>>>>>>> Stashed changes
 
   # Create the build directories
   DO "mkdir -p ${BUILD_DIR}" "0"


### PR DESCRIPTION
Add support for Ubuntu releases in 'setup-dependencies.sh'
- Add support for Ubuntu releases 13.04 (#9050)
  (https://trac.torproject.org/projects/tor/ticket/9050)
- Add support for Ubuntu releases 13.10, 14.04, 14.10
