### PR TITLE
Trac 9050

### DIFF
--- a/setup-dependencies.sh
+++ b/setup-dependencies.sh
@@ -867,7 +867,7 @@ install_virtualenv_securely() {
 }
 
 case $DISTRO_VERSION in
-  natty|wheezy|squeeze|precise|n/a)
+  natty|wheezy|squeeze|precise|n/a|raring|saucy|trusty)
 
   # Create the build directories
   DO "mkdir -p ${BUILD_DIR}" "0"


### PR DESCRIPTION
The setup script 'setup-dependencies.sh' has been tested on the supported Ubuntu releases  (13.04, 13.10, 14.04) added.
