### PR TITLE
When running unittests don't write to outside the build dir.

### DIFF
--- a/ooni/oonicli.py
+++ b/ooni/oonicli.py
@@ -101,6 +101,7 @@ def runWithDirector(logging=True, start_tor=True):
     global_options = parseOptions()
     config.global_options = global_options
     config.set_paths()
+    config.initialize_ooni_home()
     config.read_config_file()
     if global_options['verbose']:
         config.advanced.debug = True
@@ -175,7 +176,7 @@ def runWithDirector(logging=True, start_tor=True):
         sys.exit(5)
     
     d = director.start(start_tor=start_tor)
-   
+
     def setup_nettest(_):
         try:
             return deck.setup()

--- a/ooni/tests/__init__.py
+++ b/ooni/tests/__init__.py
@@ -1,8 +1,10 @@
 import socket
 from ooni.settings import config
 
+config.initialize_ooni_home('ooni_home')
 config.logging = False
 config.advanced.debug = False
+
 
 def is_internet_connected():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/ooni/tests/test_geoip.py
+++ b/ooni/tests/test_geoip.py
@@ -1,3 +1,5 @@
+import os
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -5,11 +7,12 @@ from ooni.tests import is_internet_connected
 from ooni.settings import config
 from ooni import geoip
 
+
 class TestGeoIP(unittest.TestCase):
     def setUp(self):
-        config.set_paths()
+        config.initialize_ooni_home('ooni_home')
         config.read_config_file()
- 
+
     def test_ip_to_location(self):
         location = geoip.IPToLocation('8.8.8.8')
         assert 'countrycode' in location
@@ -19,7 +22,9 @@ class TestGeoIP(unittest.TestCase):
     @defer.inlineCallbacks
     def test_probe_ip(self):
         if not is_internet_connected():
-            self.skipTest("You must be connected to the internet to run this test")
+            self.skipTest(
+                "You must be connected to the internet to run this test"
+            )
         probe_ip = geoip.ProbeIP()
         res = yield probe_ip.lookup()
         assert len(res.split('.')) == 4

--- a/ooni/tests/test_nettest.py
+++ b/ooni/tests/test_nettest.py
@@ -121,7 +121,7 @@ class TestNetTest(unittest.TestCase):
             for i in range(10):
                 f.write("%s\n" % i)
 
-        from ooni.settings import config
+        config.initialize_ooni_home('ooni_home')
         config.read_config_file()
 
     def assertCallable(self, thing):
@@ -298,7 +298,7 @@ class TestNettestTimeout(unittest.TestCase):
     def tearDown(self):
         self.factory.stopFactory()
         self.port.stopListening()
-    
+
     def test_nettest_timeout(self):
         ntl = NetTestLoader(('-u', 'http://localhost:8007/'))
         ntl.loadNetTestString(http_net_test)


### PR DESCRIPTION
This fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=743108
