### PR TITLE
Add support for having multiple test classes in a single nettest file

### DIFF
--- a/ooni/errors.py
+++ b/ooni/errors.py
@@ -264,10 +264,12 @@ class MissingRequiredOption(Exception):
     def __str__(self):
         return ','.join(self.message)
 
+
 class OONIUsageError(usage.UsageError):
     def __init__(self, net_test_loader):
         super(OONIUsageError, self).__init__()
         self.net_test_loader = net_test_loader
+
 
 class FailureToLoadNetTest(Exception):
     pass
@@ -279,6 +281,15 @@ class NoPostProcessor(Exception):
 
 class InvalidOption(Exception):
     pass
+
+
+class IncoherentOptions(Exception):
+    def __init__(self, first_options, second_options):
+        super(IncoherentOptions, self).__init__()
+        self.message = "%s is different to %s" % (first_options, second_options)
+
+    def __str__(self):
+        return self.message
 
 
 class TaskTimedOut(Exception):
@@ -303,6 +314,7 @@ class ReportLogExists(Exception):
 
 class InvalidConfigFile(Exception):
     pass
+
 
 class ConfigFileIncoherent(Exception):
     pass

--- a/ooni/nettest.py
+++ b/ooni/nettest.py
@@ -250,7 +250,9 @@ class NetTestLoader(object):
             if not usage_options:
                 usage_options = self._parseNetTestOptions(test_class)
             else:
-                assert usage_options == test_class.usageOptions
+                if usage_options != test_class.usageOptions:
+                    raise e.IncoherentOptions(usage_options.__name__,
+                                              test_class.usageOptions.__name__)
         return usage_options
 
     def loadNetTestString(self, net_test_string):

--- a/ooni/tests/test_nettest.py
+++ b/ooni/tests/test_nettest.py
@@ -6,7 +6,7 @@ from twisted.internet import defer, reactor
 from twisted.python.usage import UsageError
 
 from ooni.settings import config
-from ooni.errors import MissingRequiredOption, OONIUsageError
+from ooni.errors import MissingRequiredOption, OONIUsageError, IncoherentOptions
 from ooni.nettest import NetTest, NetTestLoader
 
 from ooni.director import Director
@@ -235,7 +235,7 @@ class TestNetTest(unittest.TestCase):
         self.verifyMethods(ntl.testCases)
         self.verifyClasses(ntl.testCases, set(('DummyTestCaseA', 'DummyTestCaseB')))
 
-        self.assertRaises(AssertionError, ntl.checkOptions)
+        self.assertRaises(IncoherentOptions, ntl.checkOptions)
 
     def test_load_with_option(self):
         ntl = NetTestLoader(dummyArgs)


### PR DESCRIPTION
Actually this was already in place, i only added a unittest and delete a clone of test_load_net_test_from_str called test_load_net_test_from_StringIO.
