### PR TITLE
SNI support for TLS handshake

### DIFF
--- a/ooni/nettest.py
+++ b/ooni/nettest.py
@@ -261,6 +261,7 @@ class NetTestLoader(object):
         into the usageOptions of the NetTestLoader.
         """
         if getattr(test_class.usageOptions, 'optParameters', None):
+            # the attribute may have `None` value, so getattr(o, name, []) can't be used
             for parameter in test_class.usageOptions.optParameters:
                 # XXX should look into if this is still necessary, seems like
                 # something left over from a bug in some nettest.
@@ -268,6 +269,9 @@ class NetTestLoader(object):
                 if len(parameter) == 5:
                     parameter.pop()
                 self.usageOptions.optParameters.append(parameter)
+
+        for flag in getattr(test_class.usageOptions, 'optFlags', []):
+            self.usageOptions.optFlags.append(flag)
 
         if getattr(test_class, 'inputFile', None):
             self.usageOptions.optParameters.append(test_class.inputFile)

--- a/ooni/nettests/experimental/tls_handshake.py
+++ b/ooni/nettests/experimental/tls_handshake.py
@@ -27,6 +27,7 @@ from socket import inet_aton as socket_inet_aton
 from socket import gethostbyname as socket_gethostbyname
 from time   import sleep
 
+import base64
 import os
 import socket
 import struct
@@ -763,7 +764,7 @@ class HandshakeTest(nettest.NetTestCase):
             ## (which would be visible in pcaps anyway, since the FQDN is
             ## never encrypted) I do not see a way for this to log any user or
             ## identifying information. Correct me if I'm wrong.
-            self.report['session_key'] = session_key
+            self.report['session_key'] = {'b64': base64.standard_b64encode(session_key)} # json can't do binary
 
             log.msg("Server certificate:\n\n%s" % server_cert)
             log.msg("Server certificate chain:\n\n%s"

--- a/ooni/nettests/experimental/tls_handshake.py
+++ b/ooni/nettests/experimental/tls_handshake.py
@@ -680,7 +680,9 @@ class HandshakeTest(nettest.NetTestCase):
                 log.debug("Max bytes in receive buffer: %d" % _read_buffer)
 
                 try:
-                    received = connection.recv(int(_read_buffer))
+                    # Zero-read triggers OpenSSL.SSL.SysCallError: (-1, 'Unexpected EOF')
+                    # The server may have sent a reply we don't know about due to network latency.
+                    received = connection.recv(int(_read_buffer)) if _read_buffer > 0 else None
                 except SSL.WantReadError, wre:
                     if connection.want_read():
                         self.state = connection.state_string()


### PR DESCRIPTION
Sometimes https traffic is blocked on SNI basis, so I've written some code to test that.

It should be probably merged after 2.0.0 release or rebased onto 2.0.
