### PR TITLE
geoip: make ProbeIP.lookup return the dns resolver too

### DIFF
--- a/ooni/tests/mocks.py
+++ b/ooni/tests/mocks.py
@@ -242,3 +242,19 @@ class MockCollectorClient(CollectorClient):
 
     def isReachable(self):
         return defer.succeed(True)
+
+
+class MockDnsResponsePayload(object):
+    def dottedQuad(self):
+        return '127.0.0.1'
+
+
+class MockDnsResponse(object):
+    payload = MockDnsResponsePayload()
+
+
+def mock_dns_lookup_address():
+    response = (
+        [MockDnsResponse()],
+    )
+    return defer.succeed(response)


### PR DESCRIPTION
Refs #616 

Wip because tests fail but ooniprobe appear to work fine.

```
$ PYTHONPATH=$PYTHONPATH:ooni coverage run $(which trial) ooni/tests/test_geoip.py
ooni.tests.test_geoip
  TestGeoIP
    test_geoip_database_version ...                                        [OK]
    test_ip_to_location ...                                                [OK]
    test_probe_ip ...                                                   [ERROR]

===============================================================================
[ERROR]
Traceback (most recent call last):
Failure: twisted.trial.util.DirtyReactorAggregateError: Reactor was unclean.
DelayedCalls: (set twisted.internet.base.DelayedCall.debug = True to debug)
<DelayedCall 0x7fa6cdc6b560 [59.9094030857s] called=0 cancelled=0 Resolver.maybeParseConfig()>
```